### PR TITLE
fix(slug_url): replace underscore

### DIFF
--- a/.github/workflows/slugify-value.yaml
+++ b/.github/workflows/slugify-value.yaml
@@ -59,8 +59,8 @@ jobs:
           [[ "${{ env.KEY_VALUE_TEST }}" == "refs/pulls/feat/-----Some----Changes_to.be------" ]]
           [[ "${{ env.KEY_VALUE_TEST_SLUG }}" == "feat-some-changes_to.be" ]]
           [[ "${{ env.KEY_VALUE_TEST_SLUG_CS }}" == "feat-Some-Changes_to.be" ]]
-          [[ "${{ env.KEY_VALUE_TEST_SLUG_URL }}" == "feat-some-changes_to-be" ]]
-          [[ "${{ env.KEY_VALUE_TEST_SLUG_URL_CS }}" == "feat-Some-Changes_to-be" ]]
+          [[ "${{ env.KEY_VALUE_TEST_SLUG_URL }}" == "feat-some-changes-to-be" ]]
+          [[ "${{ env.KEY_VALUE_TEST_SLUG_URL_CS }}" == "feat-Some-Changes-to-be" ]]
         shell: bash
 
       # Test 4
@@ -91,8 +91,8 @@ jobs:
           [[ "${{ env.KEY_VALUE_TEST }}" == "refs/pulls/feat/-----Some----Changes_to.be-----Some----Changes_to.be-----Some----Changes_to.be-----Some----Changes_to.be------" ]]
           [[ "${{ env.KEY_VALUE_TEST_SLUG }}" == "feat-some-changes_to.be-some-changes_to.be-some-changes_to.be-some-changes_to.be" ]]
           [[ "${{ env.KEY_VALUE_TEST_SLUG_CS }}" == "feat-Some-Changes_to.be-Some-Changes_to.be-Some-Changes_to.be-Some-Changes_to.be" ]]
-          [[ "${{ env.KEY_VALUE_TEST_SLUG_URL }}" == "feat-some-changes_to-be-some-changes_to-be-some-changes_to-be-some-changes_to-be" ]]
-          [[ "${{ env.KEY_VALUE_TEST_SLUG_URL_CS }}" == "feat-Some-Changes_to-be-Some-Changes_to-be-Some-Changes_to-be-Some-Changes_to-be" ]]
+          [[ "${{ env.KEY_VALUE_TEST_SLUG_URL }}" == "feat-some-changes-to-be-some-changes-to-be-some-changes-to-be-some-changes-to-be" ]]
+          [[ "${{ env.KEY_VALUE_TEST_SLUG_URL_CS }}" == "feat-Some-Changes-to-be-Some-Changes-to-be-Some-Changes-to-be-Some-Changes-to-be" ]]
         shell: bash
 
       # Test 6

--- a/.github/workflows/slugify-value.yaml
+++ b/.github/workflows/slugify-value.yaml
@@ -27,8 +27,8 @@ jobs:
           [[ "${{ env.KEY_TEST }}" == "Key_Test.values" ]]
           [[ "${{ env.KEY_TEST_SLUG }}" == "key_test.values" ]]
           [[ "${{ env.KEY_TEST_SLUG_CS }}" == "Key_Test.values" ]]
-          [[ "${{ env.KEY_TEST_SLUG_URL }}" == "key_test-values" ]]
-          [[ "${{ env.KEY_TEST_SLUG_URL_CS }}" == "Key_Test-values" ]]
+          [[ "${{ env.KEY_TEST_SLUG_URL }}" == "key-test-values" ]]
+          [[ "${{ env.KEY_TEST_SLUG_URL_CS }}" == "Key-Test-values" ]]
         shell: bash
 
       # Test 2

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Produce some `slug`-ed environment variables based on the input one.
 
 - `<env name>_SLUG_URL` (or `<env name>_SLUG_URL_CS`)
 
-  - like `<env name>_SLUG` (or `<env name>_SLUG_CS`) with the `.` character also replaced by `-`
+  - like `<env name>_SLUG` (or `<env name>_SLUG_CS`) with the `.`, and `_` characters also replaced by `-`
 
 ## Usage
 
@@ -81,7 +81,7 @@ Produce some `slug`-ed environment variables based on the input one.
 
   Will produce SLUG variables with a 80-char length
 
-- Slugify a value without 
+- Slugify a value without length limit
 
   ```yaml
   - uses: rlespinasse/slugify-value@v1.x

--- a/slugify.sh
+++ b/slugify.sh
@@ -33,7 +33,7 @@ slug() {
 }
 
 slug_url() {
-  output=$(sed -E 's#refs/[^\/]*/##;s/[^a-zA-Z0-9_-]+/-/g;s/-+/-/g;s/^-*//;s/-*$//' <<<"$1")
+  output=$(sed -E 's#refs/[^\/]*/##;s/[^a-zA-Z0-9-]+/-/g;s/-+/-/g;s/^-*//;s/-*$//' <<<"$1")
   reduce "$output"
 }
 


### PR DESCRIPTION
To be compliant with Hostname syntax, we need to remove underscore from the slug value.

Since the hostname is part of the URL, we update the SLUG_URL values instead of creating a new SLUG_HOSTNAME (for example).

Resolves #12 