### PR TITLE
README: add missing publish-env

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ Produce some `slug`-ed environment variables based on the input one.
     with:
       key: KEY_NAME
       value: value_to_slugify
+      publish-env: false
   ```
 
   Will **not** make available


### PR DESCRIPTION
It appears to be missing by mistake since the example is identical to the first one, which does set environment variables.